### PR TITLE
Add Unified TS return types

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "kcd-scripts": "^7.2.0",
     "remark": "^13.0.0",
     "remark-html": "^13.0.1",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.2",
+    "unified": "^9.2.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import type {Node, Parent, Literal} from 'unist'
+import type {Parent, Literal} from 'unist'
+import type {Attacher, Transformer as UnifiedTransformer} from 'unified'
 import parse5 from 'parse5'
 import fromParse5 from 'hast-util-from-parse5'
 import visit from 'unist-util-visit'
@@ -42,7 +43,10 @@ const getUrlString = (url: string): string | null => {
   }
 }
 
-function remarkEmbedder({transformers, cache}: RemarkEmbedderOptions) {
+const remarkEmbedder: Attacher<RemarkEmbedderOptions[]> = ({
+  transformers,
+  cache,
+}) => {
   // convert the array of transformers to one with both the transformer and the config tuple
   const transformersAndConfig: Array<{
     transformer: Transformer<unknown>
@@ -52,7 +56,7 @@ function remarkEmbedder({transformers, cache}: RemarkEmbedderOptions) {
     else return {transformer: t}
   })
 
-  return async function remarkEmbedderBase(tree: Node) {
+  const remarkEmbedderBase: UnifiedTransformer = async tree => {
     const nodeAndURL: Array<{parentNode: Parent; url: string}> = []
 
     visit(tree, 'paragraph', (paragraphNode: Parent) => {
@@ -135,6 +139,8 @@ function remarkEmbedder({transformers, cache}: RemarkEmbedderOptions) {
 
     return tree
   }
+
+  return remarkEmbedderBase
 }
 
 export default remarkEmbedder

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ const getUrlString = (url: string): string | null => {
 const remarkEmbedder: Plugin<[RemarkEmbedderOptions]> = ({
   transformers,
   cache,
-}: RemarkEmbedderOptions) => {
+}) => {
   // convert the array of transformers to one with both the transformer and the config tuple
   const transformersAndConfig: Array<{
     transformer: Transformer<unknown>

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ const remarkEmbedder: Attacher<RemarkEmbedderOptions[]> = ({
     else return {transformer: t}
   })
 
-  const remarkEmbedderBase: UnifiedTransformer = async tree => {
+  return async tree => {
     const nodeAndURL: Array<{parentNode: Parent; url: string}> = []
 
     visit(tree, 'paragraph', (paragraphNode: Parent) => {
@@ -138,9 +138,7 @@ const remarkEmbedder: Attacher<RemarkEmbedderOptions[]> = ({
     await Promise.all(promises)
 
     return tree
-  }
-
-  return remarkEmbedderBase
+  } as UnifiedTransformer
 }
 
 export default remarkEmbedder

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type {Parent, Literal} from 'unist'
-import type {Attacher, Transformer as UnifiedTransformer} from 'unified'
+import type {Plugin, Transformer as UnifiedTransformer} from 'unified'
 import parse5 from 'parse5'
 import fromParse5 from 'hast-util-from-parse5'
 import visit from 'unist-util-visit'
@@ -43,10 +43,10 @@ const getUrlString = (url: string): string | null => {
   }
 }
 
-const remarkEmbedder: Attacher<RemarkEmbedderOptions[]> = ({
+const remarkEmbedder: Plugin<[RemarkEmbedderOptions]> = ({
   transformers,
   cache,
-}) => {
+}: RemarkEmbedderOptions) => {
   // convert the array of transformers to one with both the transformer and the config tuple
   const transformersAndConfig: Array<{
     transformer: Transformer<unknown>
@@ -56,7 +56,7 @@ const remarkEmbedder: Attacher<RemarkEmbedderOptions[]> = ({
     else return {transformer: t}
   })
 
-  return async tree => {
+  const remarkEmbedderBase: UnifiedTransformer = async tree => {
     const nodeAndURL: Array<{parentNode: Parent; url: string}> = []
 
     visit(tree, 'paragraph', (paragraphNode: Parent) => {
@@ -138,7 +138,9 @@ const remarkEmbedder: Attacher<RemarkEmbedderOptions[]> = ({
     await Promise.all(promises)
 
     return tree
-  } as UnifiedTransformer
+  }
+
+  return remarkEmbedderBase
 }
 
 export default remarkEmbedder


### PR DESCRIPTION
**What**: Seems like remark plugins written in TypeScript had a signature they commonly return. For example I'm trying to use this plugin with [next-mdx-remote](https://github.com/hashicorp/next-mdx-remote/) and have the following error:

![image](https://user-images.githubusercontent.com/204463/103393343-d0728900-4ae7-11eb-8748-072165a17cb4.png)

**Why**: So this plugin can be used as other remark plugins without issues.

**How**: Checked the code of a few ([1](https://github.com/s0/remark-code-extra/blob/master/src/index.ts), [2](https://github.com/s0/remark-code-frontmatter/blob/master/src/index.ts)) remark plugins written in TS and added the corresponding `Attacher` and `Transformer` (as `UnifiedTransformer`) return types. Tests are running fine after the change.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Added `Transformer` type as `UnifiedTransformer` since there is already a type using that name, and I see it being used on, for exampe, oembed transformers package. I think this should be fine, but let me know if you think this should be changed (maybe `EmbedderTransformer`?).

Also tried to avoid changing to arrow functions, but was getting several other TS errors and found easier to type it using them. If this doesn't work I can try again using normal functions.