### PR TITLE
trim transformer html

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ const remarkEmbedder: Plugin<[RemarkEmbedderOptions]> = ({
 
           if (!html) {
             html = await transformer.getHTML(url, config)
+            html = html?.trim() as GottenHTML
             await cache?.set(cacheKey, html)
           }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ const remarkEmbedder: Plugin<[RemarkEmbedderOptions]> = ({
 
           if (!html) {
             html = await transformer.getHTML(url, config)
-            html = html?.trim() as GottenHTML
+            html = html?.trim() ?? null
             await cache?.set(cacheKey, html)
           }
 


### PR DESCRIPTION
**What**:
Trimming the `html` returned from the transformer's `getHTML` function to fix #5.

**Why**:

Without these changes a transformer that returns `html` with any leading spaces would not be inserted into the AST. For example:

```javascript
const html = `
    <div class="youtube">
        <iframe
            title=${id}
            src=${src}
            frameBorder="0"
            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
            allowFullScreen
        >
        </iframe>
    </div>
`
```

**How**:

I added a single line of code which executes `.trim()` on the returned `html` from the transformer.
_I'm not great with TypeScript but I think I handled the typing okay?_ 🤷🏼‍♂️

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation _(N/A)_
- [ ] Tests _(N/A)_
- [X] Ready to be merged

Thanks @kentcdodds for working with me to solve #5 and for considering this PR!