### PR TITLE
feat(handleError): add the ability to handle errors

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -232,6 +232,23 @@ test('can handle errors', async () => {
   consoleError.mockClear()
 })
 
+test('handleError can return null', async () => {
+  consoleError.mockImplementationOnce(() => {})
+  const transformer = getTransformer({
+    getHTML: () => Promise.reject(new Error('OH_NO_AN_ERROR_HAPPENED')),
+  })
+  const handleError = jest.fn(() => null)
+  const result = await remark()
+    .use(remarkEmbedder, {transformers: [transformer], handleError})
+    .use(remarkHTML)
+    .process(`[https://some-site.com](https://some-site.com)`)
+
+  expect(result.toString()).toMatchInlineSnapshot(
+    `<p><a href="https://some-site.com">https://some-site.com</a></p>`,
+  )
+  consoleError.mockClear()
+})
+
 // no idea why TS and remark aren't getting along here,
 // but I don't have time to look into it right now...
 /*


### PR DESCRIPTION
**What**:

feat(handleError): add the ability to handle errors

**Why**:

I describe it in the README, but basically having a build break because someone deleted a tweet is a real bummer.

**How**:

Added a new `handleError` option that will be called in the event of an error.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
