### PR TITLE
Add handleHTML function

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ return `<div><blockquote>...</blockquote><a href="...">...</a></div>`
 Some services have endpoints that you can use to get the embed HTML ([like
 twitter for example][twitter-oembed-docs]).
 
-#### `handleHTML?: (html: GottenHTML, info: { url: string, transformer: Transformer<unknown>, config: TransformerConfig }) => GottenHTML | Promise<GottenHTML>`
+#### `handleHTML?: (html: GottenHTML, info: TransformerInfo) => GottenHTML | Promise<GottenHTML>`
 
 Add optional HTML around what is returned by the transformer. This is useful
 for surrounding the returned HTML with custom HTML and classes.
@@ -179,14 +179,26 @@ for surrounding the returned HTML with custom HTML and classes.
 Here's a quick example of an HTML handler that would handle adding [TailwindCSS aspect ratio](https://github.com/tailwindlabs/tailwindcss-aspect-ratio) classes to YouTube videos:
 
 ```typescript
-function handleHTML(html, { url, transformer }) {
-   if (
+import remark from 'remark'
+import remarkEmbedder, { TransformerInfo } from '@remark-embedder/core'
+import oembedTransformer from '@remark-embedder/transformer-oembed'
+import remarkHtml from 'remark-html'
+
+const exampleMarkdown = `
+Check out this video:
+
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+`
+
+function handleHTML(html: string, info: TransformerInfo) {
+  const { url, transformer } = info
+  if (
     transformer.name === '@remark-embedder/transformer-oembed'
     || url.includes('youtube.com')
   ) {
-    return `<div class="embed-youtube aspect-w-16 aspect-h-9">${html}</div>`;
+    return `<div class="embed-youtube aspect-w-16 aspect-h-9">${html}</div>`
   }
-  return html;
+  return html
 }
 
 const result = await remark()
@@ -194,8 +206,12 @@ const result = await remark()
     transformers: [oembedTransformer],
     handleHTML,
   })
-  .use(html)
+  .use(remarkHtml)
   .process(exampleMarkdown)
+
+  // This should return:
+  // <p>Check out this video:</p>
+  // <div class="embedded-youtube aspect-w-16 aspect-h-9"><iframe width="200" height="113" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe></div>
 ```
 
 #### `handleError?: (errorInfo: ErrorInfo) => GottenHTML | Promise<GottenHTML>`

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ return `<div><blockquote>...</blockquote><a href="...">...</a></div>`
 Some services have endpoints that you can use to get the embed HTML ([like
 twitter for example][twitter-oembed-docs]).
 
-#### `handleHTML?: (html: GottenHTML, info: { url: string, transformer: Transformer<unknown>, config: TransformerConfig }) => GottenHTML | Promise<GottenHTML>
+#### `handleHTML?: (html: GottenHTML, info: { url: string, transformer: Transformer<unknown>, config: TransformerConfig }) => GottenHTML | Promise<GottenHTML>`
 
 Add optional HTML around what is returned by the transformer. This is useful
 for surrounding the returned HTML with custom HTML and classes.
@@ -198,7 +198,7 @@ const result = await remark()
   .process(exampleMarkdown)
 ```
 
-#### `handleError?: (errorInfo: ErrorInfo) => GottenHTML | Promise<GottenHTML>
+#### `handleError?: (errorInfo: ErrorInfo) => GottenHTML | Promise<GottenHTML>`
 
 ```ts
 type ErrorInfo = {

--- a/README.md
+++ b/README.md
@@ -171,6 +171,33 @@ return `<div><blockquote>...</blockquote><a href="...">...</a></div>`
 Some services have endpoints that you can use to get the embed HTML ([like
 twitter for example][twitter-oembed-docs]).
 
+#### `handleHTML?: (html: GottenHTML, info: { url: string, transformer: Transformer<unknown>, config: TransformerConfig }) => GottenHTML | Promise<GottenHTML>
+
+Add optional HTML around what is returned by the transformer. This is useful
+for surrounding the returned HTML with custom HTML and classes.
+
+Here's a quick example of an HTML handler that would handle adding [TailwindCSS aspect ratio](https://github.com/tailwindlabs/tailwindcss-aspect-ratio) classes to YouTube videos:
+
+```typescript
+function handleHTML(html, { url, transformer }) {
+   if (
+    transformer.name === '@remark-embedder/transformer-oembed'
+    || url.includes('youtube.com')
+  ) {
+    return `<div class="embed-youtube aspect-w-16 aspect-h-9">${html}</div>`;
+  }
+  return html;
+}
+
+const result = await remark()
+  .use(remarkEmbedder, {
+    transformers: [oembedTransformer],
+    handleHTML,
+  })
+  .use(html)
+  .process(exampleMarkdown)
+```
+
 #### `handleError?: (errorInfo: ErrorInfo) => GottenHTML | Promise<GottenHTML>
 
 ```ts

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -207,6 +207,40 @@ https://some-site.com/do-not-transform
   `)
 })
 
+test('handleHTML returns html', async () => {
+  const transformer = getTransformer()
+  const handleHTML = jest.fn(html => `<div>${html}</div>`)
+  const result = await remark()
+    .use(remarkEmbedder, {transformers: [transformer], handleHTML})
+    .use(remarkHTML)
+    .process(`[https://some-site.com](https://some-site.com)`)
+
+  expect(result.toString()).toMatchInlineSnapshot(
+    `<div><iframe src="https://some-site.com/"></iframe></div>`,
+  )
+})
+
+test('handleHTML gets null', async () => {
+  const handleHTML = jest.fn(() => null)
+  const result = await remark()
+    .use(remarkEmbedder, {
+      transformers: [
+        {
+          name: 'No transform',
+          getHTML: () => null,
+          shouldTransform: () => true,
+        },
+      ],
+      handleHTML,
+    })
+    .use(remarkHTML)
+    .process(`[https://some-site.com](https://some-site.com)`)
+
+  expect(result.toString()).toMatchInlineSnapshot(
+    `<p><a href="https://some-site.com">https://some-site.com</a></p>`,
+  )
+})
+
 test('can handle errors', async () => {
   consoleError.mockImplementationOnce(() => {})
   const transformer = getTransformer({

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,12 @@ type Transformer<ConfigType = unknown> = {
   shouldTransform: (url: string) => Promise<boolean> | boolean
 }
 
+type TransformerInfo = {
+  url: string
+  transformer: Transformer<unknown>
+  config: TransformerConfig
+}
+
 type RemarkEmbedderOptions = {
   cache?:
     | Map<string, GottenHTML>
@@ -28,11 +34,7 @@ type RemarkEmbedderOptions = {
   transformers: Array<Transformer<any> | [Transformer<any>, TransformerConfig]>
   handleHTML?: (
     html: GottenHTML,
-    info: {
-      url: string
-      transformer: Transformer<unknown>
-      config: TransformerConfig
-    },
+    info: TransformerInfo,
   ) => GottenHTML | Promise<GottenHTML>
   handleError?: (errorInfo: {
     error: Error
@@ -177,7 +179,7 @@ const remarkEmbedder: Plugin<[RemarkEmbedderOptions]> = ({
 }
 
 export default remarkEmbedder
-export type {RemarkEmbedderOptions, Transformer}
+export type {RemarkEmbedderOptions, Transformer, TransformerInfo}
 
 /*
 eslint


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Added new function to optionally transform the returned HTML with custom HTML.

**Why**: see discussion https://github.com/remark-embedder/core/issues/25

**How**: Duplicated `handleError()` functionality as a start, added separate html parameter

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Ready to be merged

Might want to review further but is working in all my tests. Feel free to refactor if I have done anything incorrectly or inefficiently.