### PR TITLE
fix: fix type-check

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -100,7 +100,13 @@ That's just a regular link
 
 And so is this: [neat](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
 
-[This has a title, so it's not transformed](https://some-site.com)
+[This text is not the same as the url, so it's not transformed](https://some-site.com)
+
+[https://some-site.com](https://some-site.com "This one has a title, so it's not transformed")
+
+This one has an emphasised text, so it's not transformed:
+
+[**https://some-site.com**](https://some-site.com)
       `.trim(),
     )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,8 @@ const remarkEmbedder: Plugin<[RemarkEmbedderOptions]> = ({
         node.type === 'link' &&
         !node.title &&
         node.children.length === 1 &&
-        (node.children[0] as Text).value === node.url
+        node.children[0].type === 'text' &&
+        node.children[0].value === node.url
       if (!(isText || isValidLink)) {
         return
       }


### PR DESCRIPTION
As @wooorm explained in https://github.com/remark-embedder/core/pull/33#discussion_r671825739 and can be seen in https://astexplorer.net/#/gist/e15b6dea43f639b57bfeeb894a4a44bd/57a9f7ffb478e1b2af68ade6763193c59e020df7, a `Link` can have children of different types, we need to check if the child is of type `Text` instead of assuming it always is.