### PR TITLE
fix: apply `handleHTML` to cached HTML data

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,7 +1,5 @@
-import {afterEach, expect, vi, test} from 'vitest'
-import type {Mock} from 'vitest'
-import remarkEmbedder from '../'
-import type {Transformer} from '../'
+import {afterEach, expect, vi, test, type Mock} from 'vitest'
+import remarkEmbedder, {type Transformer} from '../'
 
 // this removes the quotes around strings...
 const unquoteSerializer = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import type {Element, Root} from 'hast'
-import type {Plugin} from 'unified'
-import type {Link, Paragraph, Text} from 'mdast'
+import {type Element, type Root} from 'hast'
+import {type Plugin} from 'unified'
+import {type Link, type Paragraph, type Text} from 'mdast'
 
 type GottenHTML = string | null
 type TransformerConfig<Type = unknown> = Type

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,26 +129,26 @@ const remarkEmbedder: Plugin<[RemarkEmbedderOptions]> = ({
           const cacheKey = `remark-embedder:${transformer.name}:${url}`
           let html: GottenHTML | undefined = await cache?.get(cacheKey)
 
-          if (!html) {
-            try {
+          try {
+            if (!html) {
               html = await transformer.getHTML(url, config)
               html = html?.trim() ?? null
               await cache?.set(cacheKey, html)
+            }
 
-              // optional handleHTML transform function
-              if (handleHTML) {
-                html = await handleHTML(html, {url, transformer, config})
-                html = html?.trim() ?? null
-              }
-            } catch (e: unknown) {
-              if (handleError) {
-                const error = e as Error
-                console.error(`${errorMessageBanner}\n\n${error.message}`)
-                html = await handleError({error, url, transformer, config})
-                html = html?.trim() ?? null
-              } else {
-                throw e
-              }
+            // optional handleHTML transform function
+            if (handleHTML) {
+              html = await handleHTML(html, {url, transformer, config})
+              html = html?.trim() ?? null
+            }
+          } catch (e: unknown) {
+            if (handleError) {
+              const error = e as Error
+              console.error(`${errorMessageBanner}\n\n${error.message}`)
+              html = await handleError({error, url, transformer, config})
+              html = html?.trim() ?? null
+            } else {
+              throw e
             }
           }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Apply `handleHTML` to cached HTML data in addition to fetched HTML data.

<!-- Why are these changes necessary? -->

**Why**: `handleHTML` works only for fetched HTML data. This will give different results with and without cache.

<!-- How were these changes implemented? -->

**How**: Call `handleHTML` with a common code path for fetching and using cache.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
