### PR TITLE
feat: update dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,22 +38,22 @@
     "validate": "kcd-scripts validate"
   },
   "dependencies": {
-    "@babel/runtime": "^7.18.9",
-    "@types/hast": "^2.3.4",
-    "@types/mdast": "^3.0.10",
-    "hast-util-from-parse5": "^7.1.0",
-    "parse5": "^7.0.0",
-    "unified": "^10.1.2",
-    "unist-util-visit": "^4.1.0"
+    "@babel/runtime": "^7.23.8",
+    "@types/hast": "^3.0.3",
+    "@types/mdast": "^4.0.3",
+    "hast-util-from-parse5": "^8.0.1",
+    "parse5": "^7.1.2",
+    "unified": "^11.0.4",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.6",
-    "c8": "^7.12.0",
-    "kcd-scripts": "^12.2.0",
-    "remark": "^14.0.2",
-    "remark-html": "^15.0.1",
-    "typescript": "^4.7.4",
-    "vitest": "^0.21.0"
+    "@types/jest": "^29.5.11",
+    "c8": "^9.1.0",
+    "kcd-scripts": "^15.0.0",
+    "remark": "^15.0.1",
+    "remark-html": "^16.0.1",
+    "typescript": "^5.3.3",
+    "vitest": "^1.2.1"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js"


### PR DESCRIPTION
Hi, I'm updating to Astro v4. It uses unified v11 and I'm having trouble using this package.

I attempted a personal fork. But that introduced environment overhead that I wasn't ready to accept. lol.

In any case, this PR updates all of the dependencies to latest. I ran `test` and `build` it passed both. Feel free to disregard this for a new branch and PR. It's mostly intended as confirmation that the update appears simple enough.

![CleanShot 2024-01-24 at 06 30 15@2x](https://github.com/remark-embedder/core/assets/658360/9cd26dde-0517-4265-8ad7-a245cac52566)
